### PR TITLE
Harden Docker and Podman runtime handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ Single-server fallback (used only when `LDAP_SERVERS_CONFIG` is not set):
 | "requires a running server with a live LDAP connection" errors | The target is an offline/archive server — the error message lists the tools that do work there |
 | LDAPI connection fails for a local server | Check `serverid` has no `slapd-` prefix and the instance socket exists |
 
-No LDAP server to test against? The [Development Guide](docs/DEVELOPMENT.md) spins up test containers with Docker.
+No LDAP server to test against? The [Development Guide](docs/DEVELOPMENT.md) spins up test containers with Docker or Podman.
 
 ## Limitations
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -6,11 +6,33 @@ This guide covers setting up your development environment for LDAP Assistant MCP
 
 - Python 3.13+
 - `uv` package manager
-- Docker
+- Docker 20.10+ or Podman
 - 389 Directory Server or OpenLDAP (via containers or local install)
 - System development libraries for building `python-ldap` — see the [Prerequisites](../README.md#prerequisites) section in the README
 
 ## Development Environment Setup
+
+### Selecting a Container Runtime
+
+The helper scripts use Docker by default. To use Podman, export the runtime
+once for the shell session so create, status, and cleanup commands all target
+the same engine:
+
+```bash
+export DS_CLI=podman
+```
+
+On macOS or Windows, start the Podman VM first:
+
+```bash
+podman machine start
+```
+
+The scripts verify both the CLI and its engine before doing any work. Docker
+containers receive an explicit `host.docker.internal:host-gateway` mapping for
+the development replication topology; Podman normally supplies that alias.
+Set `DS_REPLICATION_HOST` when a custom runtime network uses a different host
+alias.
 
 ### Creating Dev Containers
 
@@ -19,6 +41,9 @@ Run the dev setup script to create 3 DS containers:
 ```bash
 ./scripts/ds-dev.sh create
 ```
+
+Containers created before the host-gateway support was added must be removed
+and recreated with the same selected runtime before using replication.
 
 This creates:
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,6 +26,19 @@ Run everything, including `live` tests, with a single command:
 
 This script handles everything: container setup, test data seeding, and pytest execution.
 
+Docker is the default container runtime. To run the same scripts with Podman,
+select it for the whole shell session (and start `podman machine` first on
+macOS or Windows):
+
+```bash
+export DS_CLI=podman
+podman machine start  # macOS/Windows only
+./scripts/ds-test.sh
+```
+
+The scripts fail before setup or cleanup when the selected CLI is missing or
+its engine is unavailable.
+
 ## Test Environment
 
 The test suite creates **3 DS containers** for multi-server testing:

--- a/scripts/ds-common.sh
+++ b/scripts/ds-common.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
 # Common functions for 389 Directory Server container management
-# Sourced by ds-dev.sh, ds-test.sh, and ds-test-local.sh
+# Sourced by ds-dev.sh, ds-test.sh, ds-test-local.sh, and ds-offline-setup.sh
+
+# Container runtime. Docker remains the deterministic default; opt into
+# Podman for the whole shell session so every lifecycle command uses the
+# same engine:
+#
+#   export DS_CLI=podman
+#   ./scripts/ds-dev.sh create
+#
+DS_CLI=${DS_CLI:-docker}
+
+# Replication reaches peer containers through their published host ports.
+# Docker Engine receives an explicit host-gateway mapping when containers are
+# created. Podman normally supplies this compatibility alias itself. Override
+# the hostname when the local runtime/network configuration requires it.
+DS_REPLICATION_HOST=${DS_REPLICATION_HOST:-host.docker.internal}
 
 # Default image
 DS_IMAGE=${DS_IMAGE:-quay.io/389ds/dirsrv}
@@ -17,7 +32,17 @@ container_is_script_owned() {
   local name=$1
   local owner
 
-  owner=$(docker inspect -f "{{index .Config.Labels \"${DS_OWNER_LABEL}\"}}" "$name" 2>/dev/null) || return 1
+  owner=$("$DS_CLI" inspect -f "{{index .Config.Labels \"${DS_OWNER_LABEL}\"}}" "$name" 2>/dev/null) || return 1
+  [[ "$owner" == "$DS_OWNER_VALUE" ]]
+}
+
+# Check whether a volume was created by these scripts. Docker and Podman both
+# expose volume labels at the top-level Labels field.
+volume_is_script_owned() {
+  local name=$1
+  local owner
+
+  owner=$("$DS_CLI" volume inspect -f "{{index .Labels \"${DS_OWNER_LABEL}\"}}" "$name" 2>/dev/null) || return 1
   [[ "$owner" == "$DS_OWNER_VALUE" ]]
 }
 
@@ -29,7 +54,7 @@ wait_for_ds() {
 
   echo "  Waiting for $name to be ready..."
   while [ $attempt -le $max_attempts ]; do
-    if docker exec "$name" ldapsearch -x -H ldap://localhost:3389 -s base -b "" > /dev/null 2>&1; then
+    if "$DS_CLI" exec "$name" ldapsearch -x -H ldap://localhost:3389 -s base -b "" > /dev/null 2>&1; then
       return 0
     fi
     sleep 5
@@ -47,7 +72,7 @@ wait_for_auth() {
 
   echo "  Waiting for Directory Manager auth..."
   while [ $attempt -le $max_attempts ]; do
-    if docker exec "$name" ldapwhoami -x -H ldap://localhost:3389 -D "cn=Directory Manager" -w "$password" > /dev/null 2>&1; then
+    if "$DS_CLI" exec "$name" ldapwhoami -x -H ldap://localhost:3389 -D "cn=Directory Manager" -w "$password" > /dev/null 2>&1; then
       return 0
     fi
     sleep 5
@@ -62,7 +87,7 @@ create_backend() {
   local base_dn=$2
 
   echo "  Creating backend and suffix..."
-  docker exec "$name" dsconf localhost backend create \
+  "$DS_CLI" exec "$name" dsconf localhost backend create \
     --suffix="$base_dn" \
     --be-name=userroot \
     --create-entries \
@@ -75,7 +100,7 @@ create_base_ous() {
   local base_dn=$2
   local password=$3
 
-  docker exec -i "$name" ldapadd \
+  "$DS_CLI" exec -i "$name" ldapadd \
     -H ldap://localhost:3389 \
     -D "cn=Directory Manager" \
     -w "$password" \
@@ -99,22 +124,29 @@ create_ds_container() {
   local ldaps_port=$3
   local password=$4
   local base_dn=$5
+  local runtime_name=${DS_CLI##*/}
+  local -a runtime_args=()
+
+  if [[ "$runtime_name" == "docker" ]]; then
+    runtime_args=(--add-host "${DS_REPLICATION_HOST}:host-gateway")
+  fi
 
   # Skip if already exists
-  if docker inspect "$name" >/dev/null 2>&1; then
+  if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
     echo "  Container $name already exists, starting..."
-    docker start "$name" >/dev/null
+    "$DS_CLI" start "$name" >/dev/null
     return 0
   fi
 
   # Create volume
-  docker volume create --label "${DS_OWNER_LABEL}=${DS_OWNER_VALUE}" "${name}-data" > /dev/null
+  "$DS_CLI" volume create --label "${DS_OWNER_LABEL}=${DS_OWNER_VALUE}" "${name}-data" > /dev/null
 
   # Create and start container
-  docker run -d \
+  "$DS_CLI" run -d \
     --name "$name" \
     --hostname localhost \
     --label "${DS_OWNER_LABEL}=${DS_OWNER_VALUE}" \
+    "${runtime_args[@]}" \
     -v "${name}-data:/data" \
     -e DS_DM_PASSWORD="$password" \
     -e DS_SUFFIX_NAME="$base_dn" \
@@ -132,23 +164,48 @@ create_ds_container() {
 remove_ds_container() {
   local name=$1
   local force=${2:-false}
+  local volume_name="${name}-data"
 
-  if docker inspect "$name" >/dev/null 2>&1; then
+  if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
     if [[ "$force" != true ]] && ! container_is_script_owned "$name"; then
       echo "Error: container '$name' exists but was not created by these scripts" >&2
-      echo "  (missing docker label ${DS_OWNER_LABEL}=${DS_OWNER_VALUE})." >&2
+      echo "  (missing container label ${DS_OWNER_LABEL}=${DS_OWNER_VALUE})." >&2
       echo "  Remove it manually, or pass --force-clean to remove it anyway." >&2
       return 1
     fi
-    docker rm -f "$name" 2>/dev/null && echo "  Removed $name" || true
+    if ! "$DS_CLI" rm -f "$name" >/dev/null 2>&1; then
+      echo "Error: failed to remove container '$name' with $DS_CLI" >&2
+      return 1
+    fi
+    echo "  Removed $name"
   fi
-  docker volume rm "${name}-data" 2>/dev/null || true
+
+  if "$DS_CLI" volume inspect "$volume_name" >/dev/null 2>&1; then
+    if [[ "$force" != true ]] && ! volume_is_script_owned "$volume_name"; then
+      echo "Error: volume '$volume_name' exists but was not created by these scripts" >&2
+      echo "  (missing volume label ${DS_OWNER_LABEL}=${DS_OWNER_VALUE})." >&2
+      echo "  Remove it manually, or pass --force-clean to remove it anyway." >&2
+      return 1
+    fi
+    if ! "$DS_CLI" volume rm "$volume_name" >/dev/null 2>&1; then
+      echo "Error: failed to remove volume '$volume_name' with $DS_CLI" >&2
+      return 1
+    fi
+    echo "  Removed $volume_name"
+  fi
 }
 
-# Check if docker is available
-require_docker() {
-  if ! command -v docker >/dev/null 2>&1; then
-    echo "Error: docker command not found" >&2
-    exit 1
+# Check that the selected container runtime executable and engine are usable.
+require_container_cli() {
+  if ! command -v "$DS_CLI" >/dev/null 2>&1; then
+    echo "Error: '$DS_CLI' command not found" >&2
+    echo "  Install it, or select another runtime with DS_CLI=<docker|podman>." >&2
+    return 1
+  fi
+
+  if ! "$DS_CLI" info >/dev/null 2>&1; then
+    echo "Error: '$DS_CLI' is installed but its engine is unavailable" >&2
+    echo "  Start Docker, or run 'podman machine start' when using Podman." >&2
+    return 1
   fi
 }

--- a/scripts/ds-dev.sh
+++ b/scripts/ds-dev.sh
@@ -42,6 +42,11 @@ Commands:
   generate [N]  Generate N operations (default: 100) for cache/stats testing
   populate      Add 100 more sample users to test replication
 
+Container runtime:
+  DS_CLI                Container CLI: docker (default) or podman
+  DS_REPLICATION_HOST   Host alias used for replication agreements
+                        (default: $DS_REPLICATION_HOST)
+
 Dev environment configuration:
   Servers:     ${#SERVERS[@]} instances with multi-supplier replication
   Base DN:     $DS_BASE_DN
@@ -81,7 +86,7 @@ add_sample_data() {
     [ $((i % 11)) -eq 0 ] && dept="HR"
 
     # Add user
-    docker exec -i "$name" ldapadd \
+    "$DS_CLI" exec -i "$name" ldapadd \
       -H ldap://localhost:3389 \
       -D "cn=Directory Manager" \
       -w "$DS_PASSWORD" \
@@ -115,7 +120,7 @@ EOF
 "
     done
 
-    docker exec -i "$name" ldapadd \
+    "$DS_CLI" exec -i "$name" ldapadd \
       -H ldap://localhost:3389 \
       -D "cn=Directory Manager" \
       -w "$DS_PASSWORD" \
@@ -138,7 +143,7 @@ add_locked_users() {
   echo "  Adding locked/inactive users to $name..."
 
   # Add a locked user (nsAccountLock=true)
-  docker exec -i "$name" ldapadd \
+  "$DS_CLI" exec -i "$name" ldapadd \
     -H ldap://localhost:3389 \
     -D "cn=Directory Manager" \
     -w "$DS_PASSWORD" \
@@ -193,7 +198,7 @@ enable_replication() {
   echo "  Enabling replication on $name (Replica ID: $replica_id)..."
 
   # Enable changelog
-  docker exec "$name" dsconf localhost replication enable \
+  "$DS_CLI" exec "$name" dsconf localhost replication enable \
     --suffix="$DS_BASE_DN" \
     --role=supplier \
     --replica-id="$replica_id" \
@@ -209,10 +214,16 @@ setup_replication_agreement() {
 
   echo "  Creating replication agreement: $source_name -> $target_name..."
 
-  # Create replication agreement using repl-agmt command
-  docker exec "$source_name" dsconf localhost repl-agmt create \
+  # Create replication agreement using repl-agmt command.
+  #
+  # All containers listen on 3389 internally, while this topology reaches
+  # peers through their distinct published host ports. create_ds_container
+  # adds an explicit Docker host-gateway mapping; Podman normally supplies the
+  # compatibility alias. DS_REPLICATION_HOST remains overridable for custom
+  # runtime or network configurations.
+  "$DS_CLI" exec "$source_name" dsconf localhost repl-agmt create \
     --suffix="$DS_BASE_DN" \
-    --host="host.docker.internal" \
+    --host="$DS_REPLICATION_HOST" \
     --port="$target_port" \
     --bind-dn="cn=replication manager,cn=config" \
     --bind-passwd="$DS_PASSWORD" \
@@ -222,7 +233,7 @@ setup_replication_agreement() {
 
   # Initialize the agreement
   sleep 1
-  docker exec "$source_name" dsconf localhost repl-agmt init \
+  "$DS_CLI" exec "$source_name" dsconf localhost repl-agmt init \
     --suffix="$DS_BASE_DN" \
     "$agmt_name" 2>&1 || echo "    Warning: Agreement init may have failed"
 }
@@ -310,7 +321,7 @@ populate_more_data() {
 
   # Add more users to ds-dev-1 (will replicate to others)
   for i in $(seq $((NUM_USERS + 1)) $((NUM_USERS + 100))); do
-    docker exec -i "ds-dev-1" ldapadd \
+    "$DS_CLI" exec -i "ds-dev-1" ldapadd \
       -H ldap://localhost:3389 \
       -D "cn=Directory Manager" \
       -w "$DS_PASSWORD" \
@@ -341,7 +352,7 @@ create_server() {
   echo "Creating $name (LDAP: $ldap_port, LDAPS: $ldaps_port, Replica ID: $replica_id)..."
 
   # Check if container already exists
-  if docker inspect "$name" >/dev/null 2>&1; then
+  if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
     echo "  Container $name already exists, skipping..."
     return 0
   fi
@@ -410,8 +421,6 @@ EOF
 }
 
 create_all() {
-  require_docker
-
   echo "Creating ${#SERVERS[@]} dev DS containers with replication..."
   echo ""
 
@@ -478,8 +487,8 @@ start_all() {
   echo "Starting all dev containers..."
   for server in "${SERVERS[@]}"; do
     IFS=':' read -r name ldap_port ldaps_port replica_id <<< "$server"
-    if docker inspect "$name" >/dev/null 2>&1; then
-      docker start "$name" > /dev/null && echo "  Started $name"
+    if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
+      "$DS_CLI" start "$name" > /dev/null && echo "  Started $name"
     else
       echo "  $name does not exist"
     fi
@@ -490,20 +499,32 @@ stop_all() {
   echo "Stopping all dev containers..."
   for server in "${SERVERS[@]}"; do
     IFS=':' read -r name ldap_port ldaps_port replica_id <<< "$server"
-    docker stop "$name" 2>/dev/null && echo "  Stopped $name" || true
+    "$DS_CLI" stop "$name" 2>/dev/null && echo "  Stopped $name" || true
   done
 }
 
 remove_all() {
   local force=false
+  local failed=false
   [[ "${1:-}" == "--force-clean" ]] && force=true
 
   echo "Removing all dev containers and volumes..."
   for server in "${SERVERS[@]}"; do
     IFS=':' read -r name ldap_port ldaps_port replica_id <<< "$server"
-    remove_ds_container "$name" "$force"
+    if ! remove_ds_container "$name" "$force"; then
+      failed=true
+    fi
   done
-  rm -f "$REPO_ROOT/servers.json" && echo "  Removed servers.json" || true
+
+  if [[ "$failed" == true ]]; then
+    echo "Error: cleanup was incomplete; preserving servers.json" >&2
+    return 1
+  fi
+
+  if [[ -f "$REPO_ROOT/servers.json" ]]; then
+    rm -f "$REPO_ROOT/servers.json"
+    echo "  Removed servers.json"
+  fi
 }
 
 show_status() {
@@ -511,8 +532,8 @@ show_status() {
   echo ""
   for server in "${SERVERS[@]}"; do
     IFS=':' read -r name ldap_port ldaps_port replica_id <<< "$server"
-    if docker inspect "$name" >/dev/null 2>&1; then
-      status=$(docker inspect -f '{{.State.Status}}' "$name")
+    if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
+      status=$("$DS_CLI" inspect -f '{{.State.Status}}' "$name")
       echo "  $name: $status (ldap://localhost:$ldap_port, Replica ID: $replica_id)"
     else
       echo "  $name: not created"
@@ -524,10 +545,10 @@ show_status() {
   echo "Replication agreements:"
   for server in "${SERVERS[@]}"; do
     IFS=':' read -r name ldap_port ldaps_port replica_id <<< "$server"
-    if docker inspect "$name" >/dev/null 2>&1; then
-      container_status=$(docker inspect -f '{{.State.Status}}' "$name")
+    if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
+      container_status=$("$DS_CLI" inspect -f '{{.State.Status}}' "$name")
       if [ "$container_status" = "running" ]; then
-        agmt_list=$(docker exec "$name" dsconf localhost repl-agmt list --suffix="$DS_BASE_DN" 2>/dev/null)
+        agmt_list=$("$DS_CLI" exec "$name" dsconf localhost repl-agmt list --suffix="$DS_BASE_DN" 2>/dev/null)
         if [ -n "$agmt_list" ]; then
           agmt_count=$(echo "$agmt_list" | grep -c "^cn:" 2>/dev/null || echo "0")
         else
@@ -547,13 +568,13 @@ show_replication_status() {
     echo "=== $name (Replica ID: $replica_id) ==="
 
     # Show replica config
-    docker exec "$name" dsconf localhost replication get \
+    "$DS_CLI" exec "$name" dsconf localhost replication get \
       --suffix="$DS_BASE_DN" 2>/dev/null | grep -E "^(nsDS5Replica|nsds5replica)" | head -5 || echo "  (replication not enabled)"
 
     echo ""
     echo "  Agreements:"
     # List agreements with status
-    docker exec "$name" dsconf localhost repl-agmt list \
+    "$DS_CLI" exec "$name" dsconf localhost repl-agmt list \
       --suffix="$DS_BASE_DN" 2>/dev/null | grep -E "^(cn:|nsds5replicaLastUpdateStatus:|nsds5replicaLastInitStatus:)" | \
       sed 's/^/    /' || echo "    (no agreements)"
     echo ""
@@ -563,6 +584,12 @@ show_replication_status() {
 # Main
 COMMAND="${1:-create}"
 COMMAND_ARG="${2:-}"
+
+case "$COMMAND" in
+  create|start|stop|remove|status|repl-status|populate)
+    require_container_cli
+    ;;
+esac
 
 case "$COMMAND" in
   create)

--- a/scripts/ds-offline-setup.sh
+++ b/scripts/ds-offline-setup.sh
@@ -16,6 +16,9 @@ set -euo pipefail
 SCRIPT_DIR=$(cd -- "$(dirname -- "$0")" && pwd)
 REPO_ROOT=$(cd -- "$SCRIPT_DIR/.." && pwd)
 
+# Sourced for $DS_CLI so this script honors the same runtime selection
+source "$SCRIPT_DIR/ds-common.sh"
+
 # Container to convert to offline mode
 OFFLINE_CONTAINER="ds-dev-3"
 OFFLINE_SERVER_NAME="ds-dev-3-offline"
@@ -37,6 +40,9 @@ Commands:
   clean    Restore all-live mode (restart container, remove host data)
   status   Show current environment state
   help     Show this help
+
+Container runtime:
+  DS_CLI   Container CLI: docker (default) or podman
 
 Prerequisites:
   Run './scripts/ds-dev.sh create' first to create the dev containers.
@@ -66,7 +72,7 @@ EOF
 }
 
 check_container_exists() {
-    if ! docker inspect "$OFFLINE_CONTAINER" > /dev/null 2>&1; then
+    if ! "$DS_CLI" inspect "$OFFLINE_CONTAINER" > /dev/null 2>&1; then
         echo "ERROR: Container '$OFFLINE_CONTAINER' not found."
         echo "Run './scripts/ds-dev.sh create' first."
         exit 1
@@ -75,10 +81,10 @@ check_container_exists() {
 
 check_container_running() {
     local status
-    status=$(docker inspect -f '{{.State.Status}}' "$OFFLINE_CONTAINER" 2>/dev/null || echo "not found")
+    status=$("$DS_CLI" inspect -f '{{.State.Status}}' "$OFFLINE_CONTAINER" 2>/dev/null || echo "not found")
     if [ "$status" != "running" ]; then
         echo "ERROR: Container '$OFFLINE_CONTAINER' is not running (status: $status)."
-        echo "Start it with: docker start $OFFLINE_CONTAINER"
+        echo "Start it with: ${DS_CLI} start $OFFLINE_CONTAINER"
         exit 1
     fi
 }
@@ -93,7 +99,7 @@ setup() {
     # Step 1: Create PREFIX directory for defaults.inf
     echo "[1/5] Creating PREFIX directory for defaults.inf..."
     mkdir -p "$OFFLINE_PREFIX/share/dirsrv/inf"
-    docker cp "$OFFLINE_CONTAINER:/usr/share/dirsrv/inf/defaults.inf" \
+    "$DS_CLI" cp "$OFFLINE_CONTAINER:/usr/share/dirsrv/inf/defaults.inf" \
         "$OFFLINE_PREFIX/share/dirsrv/inf/"
     echo "  -> $OFFLINE_PREFIX/share/dirsrv/inf/defaults.inf"
 
@@ -101,7 +107,7 @@ setup() {
     echo ""
     echo "[2/5] Copying dse.ldif to host (sudo required)..."
     sudo mkdir -p "$HOST_CONFIG_DIR"
-    docker cp "$OFFLINE_CONTAINER:$HOST_CONFIG_DIR/dse.ldif" /tmp/ds-offline-dse.ldif
+    "$DS_CLI" cp "$OFFLINE_CONTAINER:$HOST_CONFIG_DIR/dse.ldif" /tmp/ds-offline-dse.ldif
     sudo cp /tmp/ds-offline-dse.ldif "$HOST_CONFIG_DIR/dse.ldif"
     rm -f /tmp/ds-offline-dse.ldif
     sudo chown -R "$(whoami)" "$HOST_CONFIG_DIR"
@@ -113,7 +119,7 @@ setup() {
     sudo mkdir -p "$HOST_LOG_DIR"
     rm -rf /tmp/ds-offline-logs
     mkdir -p /tmp/ds-offline-logs
-    docker cp "$OFFLINE_CONTAINER:$HOST_LOG_DIR/." /tmp/ds-offline-logs/ 2>/dev/null || true
+    "$DS_CLI" cp "$OFFLINE_CONTAINER:$HOST_LOG_DIR/." /tmp/ds-offline-logs/ 2>/dev/null || true
     sudo cp -r /tmp/ds-offline-logs/* "$HOST_LOG_DIR/" 2>/dev/null || true
     rm -rf /tmp/ds-offline-logs
     sudo chown -R "$(whoami)" "$HOST_LOG_DIR"
@@ -122,7 +128,7 @@ setup() {
     # Step 4: Stop the container
     echo ""
     echo "[4/5] Stopping $OFFLINE_CONTAINER..."
-    docker stop "$OFFLINE_CONTAINER" > /dev/null 2>&1
+    "$DS_CLI" stop "$OFFLINE_CONTAINER" > /dev/null 2>&1
     echo "  Container stopped"
 
     # Step 5: Generate mixed servers.json
@@ -169,9 +175,9 @@ clean() {
     echo "  Removed host files"
 
     # Restart container
-    if docker inspect "$OFFLINE_CONTAINER" > /dev/null 2>&1; then
+    if "$DS_CLI" inspect "$OFFLINE_CONTAINER" > /dev/null 2>&1; then
         echo "Restarting $OFFLINE_CONTAINER..."
-        docker start "$OFFLINE_CONTAINER" > /dev/null 2>&1 || true
+        "$DS_CLI" start "$OFFLINE_CONTAINER" > /dev/null 2>&1 || true
         echo "  Container restarted"
     fi
 
@@ -223,8 +229,8 @@ show_status() {
     # Check containers
     echo "Containers:"
     for name in ds-dev-1 ds-dev-2 ds-dev-3; do
-        if docker inspect "$name" > /dev/null 2>&1; then
-            status=$(docker inspect -f '{{.State.Status}}' "$name")
+        if "$DS_CLI" inspect "$name" > /dev/null 2>&1; then
+            status=$("$DS_CLI" inspect -f '{{.State.Status}}' "$name")
             echo "  $name: $status"
         else
             echo "  $name: not created"
@@ -330,6 +336,12 @@ CFGEOF
 
 # Main
 COMMAND="${1:-setup}"
+
+case "$COMMAND" in
+    setup|clean|status)
+        require_container_cli
+        ;;
+esac
 
 case "$COMMAND" in
     setup)

--- a/scripts/ds-test-local.sh
+++ b/scripts/ds-test-local.sh
@@ -36,6 +36,9 @@ Options:
   --no-pytest              Skip running pytest (setup only)
   -h, --help               Show this help
 
+Container runtime:
+  DS_CLI                    Container CLI: docker (default) or podman
+
 This script tests LOCAL connection functionality by running tests
 INSIDE the DS container. This enables access to:
   - Server log files (access, error, audit logs)
@@ -77,7 +80,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-require_docker
+require_container_cli
 
 # Determine total steps (including the final summary step)
 if [[ "$RUN_PYTEST" == true ]]; then
@@ -108,15 +111,15 @@ for server in "${LOCAL_TEST_SERVERS[@]}"; do
   echo "  Creating $name (LDAP: $ldap_port)..."
 
   # Skip if already exists
-  if docker inspect "$name" >/dev/null 2>&1; then
+  if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
     echo "  Container $name already exists, starting..."
-    docker start "$name" >/dev/null
+    "$DS_CLI" start "$name" >/dev/null
   else
     # Create volume
-    docker volume create --label "${DS_OWNER_LABEL}=${DS_OWNER_VALUE}" "${name}-data" > /dev/null
+    "$DS_CLI" volume create --label "${DS_OWNER_LABEL}=${DS_OWNER_VALUE}" "${name}-data" > /dev/null
 
     # Create container with MCP code mounted
-    docker run -d \
+    "$DS_CLI" run -d \
       --name "$name" \
       --hostname localhost \
       --label "${DS_OWNER_LABEL}=${DS_OWNER_VALUE}" \
@@ -161,7 +164,7 @@ STEP=$((STEP + 1))
 # - Config is written to /tmp inside container (since /mcp is read-only)
 echo "[$STEP/$TOTAL_STEPS] Generating tests-local-servers.json inside container..."
 
-docker exec ds-local-1 bash -c "cat > /tmp/tests-local-servers.json << EOF
+"$DS_CLI" exec ds-local-1 bash -c "cat > /tmp/tests-local-servers.json << EOF
 {
   \"servers\": [
     {
@@ -194,7 +197,7 @@ echo "[$STEP/$TOTAL_STEPS] Seeding test data..."
 seed_local_test_data() {
   local name=$1
 
-  docker exec -i "$name" ldapadd \
+  "$DS_CLI" exec -i "$name" ldapadd \
     -H ldap://localhost:3389 \
     -D "cn=Directory Manager" \
     -w "$DS_PASSWORD" \
@@ -235,15 +238,15 @@ for server in "${LOCAL_TEST_SERVERS[@]}"; do
   IFS=':' read -r name ldap_port ldaps_port <<< "$server"
 
   # Check user count
-  count=$(docker exec "$name" ldapsearch -H ldap://localhost:3389 -D "cn=Directory Manager" -w "$DS_PASSWORD" -x -b "ou=people,$DS_BASE_DN" -s sub "(uid=*)" dn 2>/dev/null | grep -c "^dn:" || echo "0")
+  count=$("$DS_CLI" exec "$name" ldapsearch -H ldap://localhost:3389 -D "cn=Directory Manager" -w "$DS_PASSWORD" -x -b "ou=people,$DS_BASE_DN" -s sub "(uid=*)" dn 2>/dev/null | grep -c "^dn:" || echo "0")
   echo "  $name: $count users"
 
   # Check instance info
-  serverid=$(docker exec "$name" dsconf localhost config get nsslapd-instancedir 2>/dev/null | grep -oP 'slapd-\K[^/]+' || echo "unknown")
+  serverid=$("$DS_CLI" exec "$name" dsconf localhost config get nsslapd-instancedir 2>/dev/null | grep -oP 'slapd-\K[^/]+' || echo "unknown")
   echo "    Instance ID: $serverid"
 
   # Check log paths exist
-  if docker exec "$name" test -f /var/log/dirsrv/slapd-localhost/access 2>/dev/null; then
+  if "$DS_CLI" exec "$name" test -f /var/log/dirsrv/slapd-localhost/access 2>/dev/null; then
     echo "    Access log: exists"
   else
     echo "    Access log: not found (may be normal for fresh instance)"
@@ -258,7 +261,7 @@ if [[ "$RUN_PYTEST" == true ]]; then
   # The 389ds container is minimal - use ensurepip to bootstrap pip.
   # ensurepip may fail where pip already exists (|| true); everything else
   # must succeed or the script aborts (set -e propagates the exit code).
-  docker exec ds-local-1 bash -c "
+  "$DS_CLI" exec ds-local-1 bash -c "
     set -e
     python3 -m ensurepip --upgrade 2>/dev/null || true
     cd /mcp
@@ -272,7 +275,7 @@ if [[ "$RUN_PYTEST" == true ]]; then
 
   # Capture the pytest exit code so the summary still prints, then exit
   # with it at the end (no false green on test failures).
-  docker exec \
+  "$DS_CLI" exec \
     -e LDAP_SERVERS_CONFIG=/tmp/tests-local-servers.json \
     -e LDAP_URL="ldap://localhost:3389" \
     -e LDAP_BASE_DN="$DS_BASE_DN" \
@@ -303,7 +306,7 @@ echo ""
 echo "Configuration: /tmp/tests-local-servers.json (inside container)"
 echo ""
 echo "To run tests manually inside the container:"
-echo "  docker exec -it ds-local-1 bash"
+echo "  ${DS_CLI} exec -it ds-local-1 bash"
 echo "  cd /mcp"
 echo "  export LDAP_SERVERS_CONFIG=/tmp/tests-local-servers.json"
 echo "  export LDAP_IS_LOCAL=true"

--- a/scripts/ds-test.sh
+++ b/scripts/ds-test.sh
@@ -37,6 +37,9 @@ Options:
   --no-pytest              Skip running pytest (useful for CI)
   -h, --help               Show this help
 
+Container runtime:
+  DS_CLI                    Container CLI: docker (default) or podman
+
 Creates ${#TEST_SERVERS[@]} test containers:
   ds-test-1  ldap://localhost:33891
   ds-test-2  ldap://localhost:33892
@@ -84,7 +87,7 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-require_docker
+require_container_cli
 
 # Determine total steps based on options
 if [[ "$RUN_PYTEST" == true ]]; then
@@ -119,8 +122,8 @@ for server in "${TEST_SERVERS[@]}"; do
   create_ds_container "$name" "$ldap_port" "$ldaps_port" "$DS_PASSWORD" "$DS_BASE_DN"
 
   # Skip waiting if container already existed
-  if docker inspect "$name" >/dev/null 2>&1; then
-    status=$(docker inspect -f '{{.State.Status}}' "$name")
+  if "$DS_CLI" inspect "$name" >/dev/null 2>&1; then
+    status=$("$DS_CLI" inspect -f '{{.State.Status}}' "$name")
     if [[ "$status" == "running" ]]; then
       # Wait for DS
       if ! wait_for_ds "$name"; then
@@ -190,7 +193,7 @@ if [[ "$SKIP_SEED" != true ]]; then
     local name=$1
     local suffix=$2
 
-    docker exec -i "$name" ldapadd \
+    "$DS_CLI" exec -i "$name" ldapadd \
       -H ldap://localhost:3389 \
       -D "cn=Directory Manager" \
       -w "$DS_PASSWORD" \
@@ -327,7 +330,7 @@ STEP=$((STEP + 1))
 echo "[$STEP/$TOTAL_STEPS] Verifying test data..."
 for server in "${TEST_SERVERS[@]}"; do
   IFS=':' read -r name ldap_port ldaps_port <<< "$server"
-  count=$(docker exec "$name" ldapsearch -H ldap://localhost:3389 -D "cn=Directory Manager" -w "$DS_PASSWORD" -x -b "ou=people,$DS_BASE_DN" -s sub "(uid=*)" dn 2>/dev/null | grep -c "^dn:" || echo "0")
+  count=$("$DS_CLI" exec "$name" ldapsearch -H ldap://localhost:3389 -D "cn=Directory Manager" -w "$DS_PASSWORD" -x -b "ou=people,$DS_BASE_DN" -s sub "(uid=*)" dn 2>/dev/null | grep -c "^dn:" || echo "0")
   echo "  $name: $count users found"
 done
 STEP=$((STEP + 1))

--- a/tests/dirsrv_mcp/README.md
+++ b/tests/dirsrv_mcp/README.md
@@ -8,7 +8,7 @@ Shared pytest fixtures (server config, expected data) live in `conftest.py`. The
 
 | Category | Test files |
 |----------|-----------|
-| Live-server tests (need the Docker containers from `scripts/ds-test.sh`) | `test_users`, `test_groups`, `test_search`, `test_monitoring`, `test_config`, `test_health`, `test_indexes`, `test_performance`, `test_replication`, `test_anonymous`, `test_multiserver`, `test_local_connection`, `test_ssl_config` |
+| Live-server tests (need the Docker or Podman containers from `scripts/ds-test.sh`) | `test_users`, `test_groups`, `test_search`, `test_monitoring`, `test_config`, `test_health`, `test_indexes`, `test_performance`, `test_replication`, `test_anonymous`, `test_multiserver`, `test_local_connection`, `test_ssl_config` |
 | Offline/archive tests (no LDAP connection needed) | `test_offline_mode`, `test_archive_mode`, `test_archive_tools`, `test_logs` |
 | Unit/no-server tests | `test_privacy`, `test_privacy_gaps`, `test_debug_mode`, `test_middleware` |
 

--- a/tests/test_container_runtime_scripts.py
+++ b/tests/test_container_runtime_scripts.py
@@ -1,0 +1,237 @@
+"""Regression tests for Docker/Podman selection in the DS helper scripts.
+
+The tests use a fake container CLI and temporary script copies. They never
+inspect or mutate real containers, volumes, networks, or server configs.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+
+
+def _write_fake_cli(tmp_path: Path, name: str) -> tuple[Path, Path]:
+    cli = tmp_path / name
+    log = tmp_path / f"{name}.log"
+    cli.write_text(
+        """#!/bin/bash
+printf '%s\\n' "$*" >> "$FAKE_CLI_LOG"
+
+case "$1" in
+  info)
+    exit "${FAKE_INFO_EXIT:-0}"
+    ;;
+  inspect)
+    if [[ "$*" == *'.Config.Labels'* ]]; then
+      printf '%s\\n' "${FAKE_OWNER:-ds-scripts}"
+      exit "${FAKE_OWNER_EXIT:-0}"
+    fi
+    exit "${FAKE_CONTAINER_INSPECT_EXIT:-1}"
+    ;;
+  volume)
+    case "$2" in
+      create)
+        exit "${FAKE_VOLUME_CREATE_EXIT:-0}"
+        ;;
+      inspect)
+        if [[ "$*" == *'.Labels'* ]]; then
+          printf '%s\\n' "${FAKE_VOLUME_OWNER:-ds-scripts}"
+          exit "${FAKE_VOLUME_OWNER_EXIT:-0}"
+        fi
+        exit "${FAKE_VOLUME_INSPECT_EXIT:-1}"
+        ;;
+      rm)
+        exit "${FAKE_VOLUME_RM_EXIT:-0}"
+        ;;
+    esac
+    ;;
+  rm)
+    exit "${FAKE_RM_EXIT:-0}"
+    ;;
+  run|start|stop|exec|cp)
+    exit 0
+    ;;
+esac
+
+exit 0
+""",
+        encoding="utf-8",
+    )
+    cli.chmod(0o755)
+    return cli, log
+
+
+def _environment(**overrides: str) -> dict[str, str]:
+    env = os.environ.copy()
+    env.pop("DS_CLI", None)
+    env.update(overrides)
+    return env
+
+
+def _run_script(
+    script: Path,
+    *args: str,
+    env: dict[str, str] | None = None,
+    cwd: Path = REPO_ROOT,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(script), *args],
+        cwd=cwd,
+        env=env or _environment(),
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+
+
+def _run_common_function(
+    tmp_path: Path,
+    cli_name: str,
+) -> tuple[subprocess.CompletedProcess[str], str]:
+    cli, log = _write_fake_cli(tmp_path, cli_name)
+    command = (
+        f"source {shlex.quote(str(SCRIPTS_DIR / 'ds-common.sh'))}; "
+        "require_container_cli; "
+        "create_ds_container ds-unit 4389 4636 password dc=example,dc=com"
+    )
+    result = subprocess.run(
+        ["/bin/bash", "-c", command],
+        cwd=REPO_ROOT,
+        env=_environment(DS_CLI=str(cli), FAKE_CLI_LOG=str(log)),
+        text=True,
+        capture_output=True,
+        timeout=10,
+        check=False,
+    )
+    return result, log.read_text(encoding="utf-8")
+
+
+def test_status_fails_when_selected_cli_is_missing(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-container-cli"
+    result = _run_script(
+        SCRIPTS_DIR / "ds-dev.sh",
+        "status",
+        env=_environment(DS_CLI=str(missing)),
+    )
+
+    assert result.returncode != 0
+    assert "command not found" in result.stderr
+    assert "not created" not in result.stdout
+
+
+def test_status_fails_when_selected_engine_is_unavailable(tmp_path: Path) -> None:
+    cli, log = _write_fake_cli(tmp_path, "docker")
+    result = _run_script(
+        SCRIPTS_DIR / "ds-dev.sh",
+        "status",
+        env=_environment(
+            DS_CLI=str(cli),
+            FAKE_CLI_LOG=str(log),
+            FAKE_INFO_EXIT="1",
+        ),
+    )
+
+    assert result.returncode != 0
+    assert "engine is unavailable" in result.stderr
+    assert "not created" not in result.stdout
+
+
+def test_offline_status_validates_runtime_before_inspection(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-container-cli"
+    result = _run_script(
+        SCRIPTS_DIR / "ds-offline-setup.sh",
+        "status",
+        env=_environment(DS_CLI=str(missing)),
+    )
+
+    assert result.returncode != 0
+    assert "command not found" in result.stderr
+    assert "Offline mode testing environment status" not in result.stdout
+
+
+def test_help_does_not_require_a_container_runtime(tmp_path: Path) -> None:
+    missing = tmp_path / "missing-container-cli"
+    env = _environment(DS_CLI=str(missing))
+
+    dev = _run_script(SCRIPTS_DIR / "ds-dev.sh", "help", env=env)
+    offline = _run_script(SCRIPTS_DIR / "ds-offline-setup.sh", "help", env=env)
+
+    assert dev.returncode == 0
+    assert offline.returncode == 0
+
+
+def test_docker_is_the_deterministic_default(tmp_path: Path) -> None:
+    cli, log = _write_fake_cli(tmp_path, "docker")
+    env = _environment(
+        PATH=f"{tmp_path}{os.pathsep}{os.environ['PATH']}",
+        FAKE_CLI_LOG=str(log),
+    )
+
+    result = _run_script(SCRIPTS_DIR / "ds-dev.sh", "status", env=env)
+
+    assert result.returncode == 0
+    calls = log.read_text(encoding="utf-8")
+    assert "info" in calls
+    assert "inspect ds-dev-1" in calls
+    assert cli.name == "docker"
+
+
+def test_explicit_podman_selection_is_preserved(tmp_path: Path) -> None:
+    cli, log = _write_fake_cli(tmp_path, "podman")
+    result = _run_script(
+        SCRIPTS_DIR / "ds-dev.sh",
+        "status",
+        env=_environment(DS_CLI=str(cli), FAKE_CLI_LOG=str(log)),
+    )
+
+    assert result.returncode == 0
+    calls = log.read_text(encoding="utf-8")
+    assert "info" in calls
+    assert "inspect ds-dev-1" in calls
+
+
+def test_docker_container_gets_explicit_host_gateway(tmp_path: Path) -> None:
+    result, calls = _run_common_function(tmp_path, "docker")
+
+    assert result.returncode == 0, result.stderr
+    assert "--add-host host.docker.internal:host-gateway" in calls
+
+
+def test_podman_container_uses_runtime_provided_host_alias(tmp_path: Path) -> None:
+    result, calls = _run_common_function(tmp_path, "podman")
+
+    assert result.returncode == 0, result.stderr
+    assert "--add-host" not in calls
+
+
+def test_failed_cleanup_keeps_generated_config(tmp_path: Path) -> None:
+    copied_scripts = tmp_path / "scripts"
+    copied_scripts.mkdir()
+    shutil.copy2(SCRIPTS_DIR / "ds-common.sh", copied_scripts / "ds-common.sh")
+    shutil.copy2(SCRIPTS_DIR / "ds-dev.sh", copied_scripts / "ds-dev.sh")
+
+    config = tmp_path / "servers.json"
+    config.write_text("sentinel\n", encoding="utf-8")
+    cli, log = _write_fake_cli(tmp_path, "docker")
+    result = _run_script(
+        copied_scripts / "ds-dev.sh",
+        "remove",
+        cwd=tmp_path,
+        env=_environment(
+            DS_CLI=str(cli),
+            FAKE_CLI_LOG=str(log),
+            FAKE_CONTAINER_INSPECT_EXIT="0",
+            FAKE_RM_EXIT="1",
+        ),
+    )
+
+    assert result.returncode != 0
+    assert config.read_text(encoding="utf-8") == "sentinel\n"


### PR DESCRIPTION
- Validate the selected container runtime before lifecycle operations.
- Add Docker host-gateway mapping while preserving Podman behavior.
- Refuse cleanup of unowned resources and retain configuration on failure.
- Document runtime selection and add fake-runtime regression tests.